### PR TITLE
Fix tests that fails when locale has decimal comma

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,11 @@ dependencies {
 apply from: 'version.gradle'
 
 task parallelTest(type: Test) {
+    // Forcing locale is needed because some tests examine the
+    // locale-dependent formatting of numbers and dates.
+    systemProperty 'user.language', 'en'
+    systemProperty 'user.country', 'US'
+
     maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
     useJUnit {
         excludeCategories 'net.pterodactylus.sone.test.NotParallel'


### PR DESCRIPTION
The locale is set locally for each failing test.