### PR TITLE
Only check all WoT IDs once every 10 minutes

### DIFF
--- a/src/main/kotlin/net/pterodactylus/sone/freenet/wot/IdentityManagerImpl.kt
+++ b/src/main/kotlin/net/pterodactylus/sone/freenet/wot/IdentityManagerImpl.kt
@@ -24,6 +24,7 @@ import com.google.inject.Singleton
 import net.pterodactylus.sone.core.event.StrictFilteringActivatedEvent
 import net.pterodactylus.sone.core.event.StrictFilteringDeactivatedEvent
 import net.pterodactylus.util.service.AbstractService
+import java.util.concurrent.TimeUnit.MINUTES
 import java.util.concurrent.TimeUnit.SECONDS
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.logging.Level
@@ -80,8 +81,8 @@ class IdentityManagerImpl @Inject constructor(
 				logger.log(Level.SEVERE, "Uncaught exception in IdentityManager thread!", e)
 			}
 
-			/* wait a minute before checking again. */
-			sleep(SECONDS.toMillis(60))
+			/* wait ten minutes before checking again. */
+			sleep(MINUTES.toMillis(10))
 		}
 	}
 


### PR DESCRIPTION
Checking once per minute hits a slow path in WoT.

Yes, we should fix WoT to make it cheap to check all IDs, or convert Sone to using the subscription-based WoT API, but since both don’t seem viable in the near term, this stronger rate-limiting should avoid overloading the node.