### PR TITLE
Rename WoT  profile to report or like

### DIFF
--- a/src/main/resources/i18n/sone.de.properties
+++ b/src/main/resources/i18n/sone.de.properties
@@ -361,7 +361,7 @@ View.SoneMenu.Link.AllAlbums=alle Alben
 View.SoneMenu.WebOfTrustLink=„Web of Trust“ Profil
 
 View.Post.UnknownAuthor=(unbekannt)
-View.Post.WebOfTrustLink=WoT-Profil
+View.Post.WebOfTrustLink=⚠ / 🖤️ Sone
 View.Post.Permalink=Nachrichtenlink
 View.Post.PermalinkAuthor=Autorenlink
 View.Post.Bookmarks.PostIsBookmarked=Nachricht ist ein Favorit, klicken, um Favoritenmarkierung zu entfernen

--- a/src/main/resources/i18n/sone.de.properties
+++ b/src/main/resources/i18n/sone.de.properties
@@ -361,7 +361,7 @@ View.SoneMenu.Link.AllAlbums=alle Alben
 View.SoneMenu.WebOfTrustLink=„Web of Trust“ Profil
 
 View.Post.UnknownAuthor=(unbekannt)
-View.Post.WebOfTrustLink=⚠ / 🖤️ Sone
+View.Post.WebOfTrustLink=Block/Endorse
 View.Post.Permalink=Nachrichtenlink
 View.Post.PermalinkAuthor=Autorenlink
 View.Post.Bookmarks.PostIsBookmarked=Nachricht ist ein Favorit, klicken, um Favoritenmarkierung zu entfernen

--- a/src/main/resources/i18n/sone.en.properties
+++ b/src/main/resources/i18n/sone.en.properties
@@ -361,7 +361,7 @@ View.SoneMenu.Link.AllAlbums=all albums
 View.SoneMenu.WebOfTrustLink=web of trust profile
 
 View.Post.UnknownAuthor=(unknown)
-View.Post.WebOfTrustLink=⚠ / 🖤️ Sone
+View.Post.WebOfTrustLink=Block/Endorse
 View.Post.Permalink=link post
 View.Post.PermalinkAuthor=link author
 View.Post.Bookmarks.PostIsBookmarked=Post is bookmarked, click to remove from bookmarks

--- a/src/main/resources/i18n/sone.en.properties
+++ b/src/main/resources/i18n/sone.en.properties
@@ -361,7 +361,7 @@ View.SoneMenu.Link.AllAlbums=all albums
 View.SoneMenu.WebOfTrustLink=web of trust profile
 
 View.Post.UnknownAuthor=(unknown)
-View.Post.WebOfTrustLink=WoT Profile
+View.Post.WebOfTrustLink=⚠ / 🖤️ Sone
 View.Post.Permalink=link post
 View.Post.PermalinkAuthor=link author
 View.Post.Bookmarks.PostIsBookmarked=Post is bookmarked, click to remove from bookmarks

--- a/src/main/resources/i18n/sone.es.properties
+++ b/src/main/resources/i18n/sone.es.properties
@@ -361,7 +361,7 @@ View.SoneMenu.Link.AllAlbums=todos los albumes
 View.SoneMenu.WebOfTrustLink=perfil de web of trust
 
 View.Post.UnknownAuthor=(desconocido)
-View.Post.WebOfTrustLink=⚠ / 🖤️ Sone
+View.Post.WebOfTrustLink=Block/Endorse
 View.Post.Permalink=link a la publicación
 View.Post.PermalinkAuthor=link al autor
 View.Post.Bookmarks.PostIsBookmarked=La publicación esta marcada, clica para eliminarla de los marcadores

--- a/src/main/resources/i18n/sone.es.properties
+++ b/src/main/resources/i18n/sone.es.properties
@@ -361,7 +361,7 @@ View.SoneMenu.Link.AllAlbums=todos los albumes
 View.SoneMenu.WebOfTrustLink=perfil de web of trust
 
 View.Post.UnknownAuthor=(desconocido)
-View.Post.WebOfTrustLink=perfil de web of trust
+View.Post.WebOfTrustLink=⚠ / 🖤️ Sone
 View.Post.Permalink=link a la publicación
 View.Post.PermalinkAuthor=link al autor
 View.Post.Bookmarks.PostIsBookmarked=La publicación esta marcada, clica para eliminarla de los marcadores

--- a/src/main/resources/i18n/sone.fr.properties
+++ b/src/main/resources/i18n/sone.fr.properties
@@ -361,7 +361,7 @@ View.SoneMenu.Link.AllAlbums=Tous les Albums
 View.SoneMenu.WebOfTrustLink=Profile web of trust
 
 View.Post.UnknownAuthor=(inconnu)
-View.Post.WebOfTrustLink=Profil Web of Trust
+View.Post.WebOfTrustLink=⚠ / 🖤️ Sone
 View.Post.Permalink=Lier le message
 View.Post.PermalinkAuthor=Lier l'auteur
 View.Post.Bookmarks.PostIsBookmarked=Ce message a été ajouté aux marque-pages, cliquer pour retirer des marque-pages

--- a/src/main/resources/i18n/sone.fr.properties
+++ b/src/main/resources/i18n/sone.fr.properties
@@ -361,7 +361,7 @@ View.SoneMenu.Link.AllAlbums=Tous les Albums
 View.SoneMenu.WebOfTrustLink=Profile web of trust
 
 View.Post.UnknownAuthor=(inconnu)
-View.Post.WebOfTrustLink=⚠ / 🖤️ Sone
+View.Post.WebOfTrustLink=Block/Endorse
 View.Post.Permalink=Lier le message
 View.Post.PermalinkAuthor=Lier l'auteur
 View.Post.Bookmarks.PostIsBookmarked=Ce message a été ajouté aux marque-pages, cliquer pour retirer des marque-pages

--- a/src/main/resources/i18n/sone.it.properties
+++ b/src/main/resources/i18n/sone.it.properties
@@ -361,7 +361,7 @@ View.SoneMenu.Link.AllAlbums=all albums
 View.SoneMenu.WebOfTrustLink=web of trust profile
 
 View.Post.UnknownAuthor=(sconociuto)
-View.Post.WebOfTrustLink=⚠ / 🖤️ Sone
+View.Post.WebOfTrustLink=Block/Endorse
 View.Post.Permalink=link post
 View.Post.PermalinkAuthor=link author
 View.Post.Bookmarks.PostIsBookmarked=Post is bookmarked, click to remove from bookmarks

--- a/src/main/resources/i18n/sone.it.properties
+++ b/src/main/resources/i18n/sone.it.properties
@@ -361,7 +361,7 @@ View.SoneMenu.Link.AllAlbums=all albums
 View.SoneMenu.WebOfTrustLink=web of trust profile
 
 View.Post.UnknownAuthor=(sconociuto)
-View.Post.WebOfTrustLink=WoT Profile
+View.Post.WebOfTrustLink=⚠ / 🖤️ Sone
 View.Post.Permalink=link post
 View.Post.PermalinkAuthor=link author
 View.Post.Bookmarks.PostIsBookmarked=Post is bookmarked, click to remove from bookmarks

--- a/src/main/resources/i18n/sone.ja.properties
+++ b/src/main/resources/i18n/sone.ja.properties
@@ -361,7 +361,7 @@ View.SoneMenu.Link.AllAlbums=全てのアルバム
 View.SoneMenu.WebOfTrustLink=Web of Trustプロフィール
 
 View.Post.UnknownAuthor=（不明）
-View.Post.WebOfTrustLink=⚠ / 🖤️ Sone
+View.Post.WebOfTrustLink=Block/Endorse
 View.Post.Permalink=投稿へのリンク
 View.Post.PermalinkAuthor=著者へのリンク
 View.Post.Bookmarks.PostIsBookmarked=投稿はブックマークされています。クリックするとブックマークを解除します

--- a/src/main/resources/i18n/sone.ja.properties
+++ b/src/main/resources/i18n/sone.ja.properties
@@ -361,7 +361,7 @@ View.SoneMenu.Link.AllAlbums=全てのアルバム
 View.SoneMenu.WebOfTrustLink=Web of Trustプロフィール
 
 View.Post.UnknownAuthor=（不明）
-View.Post.WebOfTrustLink=Web of Trustプロフィール
+View.Post.WebOfTrustLink=⚠ / 🖤️ Sone
 View.Post.Permalink=投稿へのリンク
 View.Post.PermalinkAuthor=著者へのリンク
 View.Post.Bookmarks.PostIsBookmarked=投稿はブックマークされています。クリックするとブックマークを解除します

--- a/src/main/resources/i18n/sone.no.properties
+++ b/src/main/resources/i18n/sone.no.properties
@@ -361,7 +361,7 @@ View.SoneMenu.Link.AllAlbums=alle album
 View.SoneMenu.WebOfTrustLink='web of trust'-profil
 
 View.Post.UnknownAuthor=(ukjent)
-View.Post.WebOfTrustLink=⚠ / 🖤️ Sonen
+View.Post.WebOfTrustLink=Block/Endorsen
 View.Post.Permalink=link innlegg
 View.Post.PermalinkAuthor=link forfatter
 View.Post.Bookmarks.PostIsBookmarked=Innlegg er bokmerket. Klikk for å fjerne bokmerke

--- a/src/main/resources/i18n/sone.no.properties
+++ b/src/main/resources/i18n/sone.no.properties
@@ -361,7 +361,7 @@ View.SoneMenu.Link.AllAlbums=alle album
 View.SoneMenu.WebOfTrustLink='web of trust'-profil
 
 View.Post.UnknownAuthor=(ukjent)
-View.Post.WebOfTrustLink='web of trust'-profil
+View.Post.WebOfTrustLink=⚠ / 🖤️ Sonen
 View.Post.Permalink=link innlegg
 View.Post.PermalinkAuthor=link forfatter
 View.Post.Bookmarks.PostIsBookmarked=Innlegg er bokmerket. Klikk for å fjerne bokmerke

--- a/src/main/resources/i18n/sone.pl.properties
+++ b/src/main/resources/i18n/sone.pl.properties
@@ -361,7 +361,7 @@ View.SoneMenu.Link.AllAlbums=wszystkie albumy
 View.SoneMenu.WebOfTrustLink=Profil sieci zaufania
 
 View.Post.UnknownAuthor=(nieznany)
-View.Post.WebOfTrustLink=⚠ / 🖤️ Sone
+View.Post.WebOfTrustLink=Block/Endorse
 View.Post.Permalink=linkuj post
 View.Post.PermalinkAuthor=linkuj autora
 View.Post.Bookmarks.PostIsBookmarked=Post został oznaczony, kliknij, żeby odznaczyć

--- a/src/main/resources/i18n/sone.pl.properties
+++ b/src/main/resources/i18n/sone.pl.properties
@@ -361,7 +361,7 @@ View.SoneMenu.Link.AllAlbums=wszystkie albumy
 View.SoneMenu.WebOfTrustLink=Profil sieci zaufania
 
 View.Post.UnknownAuthor=(nieznany)
-View.Post.WebOfTrustLink=Profil sieci zaufania
+View.Post.WebOfTrustLink=⚠ / 🖤️ Sone
 View.Post.Permalink=linkuj post
 View.Post.PermalinkAuthor=linkuj autora
 View.Post.Bookmarks.PostIsBookmarked=Post został oznaczony, kliknij, żeby odznaczyć

--- a/src/main/resources/i18n/sone.ru.properties
+++ b/src/main/resources/i18n/sone.ru.properties
@@ -361,7 +361,7 @@ View.SoneMenu.Link.AllAlbums=все альбомы
 View.SoneMenu.WebOfTrustLink=профиль web of trust
 
 View.Post.UnknownAuthor=(неизвестно)
-View.Post.WebOfTrustLink=⚠ / 🖤️ Sone
+View.Post.WebOfTrustLink=Block/Endorse
 View.Post.Permalink=ссылка на сообщение
 View.Post.PermalinkAuthor=ссылка на автора
 View.Post.Bookmarks.PostIsBookmarked=Сообщение в закладках. Нажмите, чтобы удалить из закладок.

--- a/src/main/resources/i18n/sone.ru.properties
+++ b/src/main/resources/i18n/sone.ru.properties
@@ -361,7 +361,7 @@ View.SoneMenu.Link.AllAlbums=все альбомы
 View.SoneMenu.WebOfTrustLink=профиль web of trust
 
 View.Post.UnknownAuthor=(неизвестно)
-View.Post.WebOfTrustLink=профиль web of trust
+View.Post.WebOfTrustLink=⚠ / 🖤️ Sone
 View.Post.Permalink=ссылка на сообщение
 View.Post.PermalinkAuthor=ссылка на автора
 View.Post.Bookmarks.PostIsBookmarked=Сообщение в закладках. Нажмите, чтобы удалить из закладок.


### PR DESCRIPTION
This changes the technical name ("open WoT") to the action users can actually take ("report and block or support").

It is purely a localization change.

This resolves my long-standing pondering how to make trust handling from Sone intuitive without making it so quick that it would invite spamming trust or distrust.